### PR TITLE
[brew] Implement Temple formulae

### DIFF
--- a/temple.rb
+++ b/temple.rb
@@ -1,5 +1,5 @@
 class Temple < Formula
-  desc "A Software Framework for automatically generating microservices from a high level DSL"
+  desc "A framework for generating microservice infrastructure for platform-based systems"
   version "0.1.0"
   homepage "https://templeeight.github.io/temple-docs/"
   url "https://github.com/TempleEight/temple/releases/download/v0.1.0/temple-latest"

--- a/temple.rb
+++ b/temple.rb
@@ -1,9 +1,9 @@
 class Temple < Formula
   desc "A Software Framework for automatically generating microservices from a high level DSL"
-  version "0.001"
-  homepage "https://templeeight.github.io/"
-  url "https://github.com/TempleEight/temple/releases/download/v0.01/temple-latest"
-  sha256 "7b4c97734bdf7a2b0c45a499115e094e866830c427becaa60f777fb0cfe3dc1d"
+  version "0.1.0"
+  homepage "https://templeeight.github.io/temple-docs/"
+  url "https://github.com/TempleEight/temple/releases/download/v0.1.0/temple-latest"
+  sha256 "875e66d382f256daea838f3e5b5d1c3392c272016c19974e38c34548ad8b9792"
 
 
   def install

--- a/temple.rb
+++ b/temple.rb
@@ -2,16 +2,12 @@ class Temple < Formula
   desc "A Software Framework for automatically generating microservices from a high level DSL"
   version "0.001"
   homepage "https://templeeight.github.io/"
-  url "https://github.com/TempleEight/temple/releases/latest/download/temple-latest"
-  sha256 "a06237d4e674beec2258d1e2c80bf0c57ab4312e383e81f137879cfb09b00574"
+  url "https://github.com/TempleEight/temple/releases/download/v0.01/temple-latest"
+  sha256 "7b4c97734bdf7a2b0c45a499115e094e866830c427becaa60f777fb0cfe3dc1d"
 
 
   def install
     system "mv ./temple-latest temple"
     bin.install "./temple"
-  end
-
-  test do
-    system "false"
   end
 end


### PR DESCRIPTION
This PR adds the Temple Homebrew Formula to the public tap repo, allowing it to be installed via brew.


## Test Plan

Clone this repository and run 
> `brew install temple.rb` 
Check that the temple app is installed with:
```
$> temple

temple 0.1 (c) 2020 TempleEight
Usage:	temple [OPTIONS] SUBCOMMAND
  -h, --help      Show help message
  -v, --version   Show version of this program

Subcommands:
  generate
Run 'temple SUBCOMMAND --help' for more information on a command.
```
